### PR TITLE
Adds the basics of a webrtc based interview tool

### DIFF
--- a/assets/js/interview.js
+++ b/assets/js/interview.js
@@ -1,0 +1,44 @@
+
+
+$(document).ready(function(){
+
+    var webrtc = new SimpleWebRTC({
+        peerConnectionConfig: { iceServers: [{"url": "stun:redecentralize.net:3478"}]},
+        localVideoEl: 'localVideo',
+        remoteVideosEl: 'remoteVideo',
+        autoRequestMedia: true
+    })
+
+    var recorder;
+
+    webrtc.on('videoAdded', function(video, peer){
+        recorder = RecordRTC(peer.stream, {
+           type: 'video',
+           width: 320,
+           height: 240
+        });
+    })
+
+
+    $('#start-record').click(function(){
+        recorder.startRecording()
+        return false
+    })
+    $('#stop-record').click(function(){
+        recorder.stopRecording(function(videoURL) {
+           window.open(videoURL);
+        })
+        return false
+    })
+    $('#save-record').click(function(){
+        recorder.save()
+        return false
+    })
+
+    webrtc.on('readyToCall', function () {
+        webrtc.joinRoom('redecentralise', function (err, roomInfo) {
+            console.log(err)
+            console.log(roomInfo)
+        });
+    });
+})

--- a/interview-tool/index.html
+++ b/interview-tool/index.html
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Interview Tool
+id: interview-tool
+---
+
+<script src="http://simplewebrtc.com/latest.js"></script>
+<script src="https://www.webrtc-experiment.com/RecordRTC.js"></script>
+<script type="text/javascript" src="/assets/js/interview.js"></script>
+
+<div class="row">
+    <div class="col-sm-12">
+        <h2>Interview tool
+        <small>WebRTC FTW!</small>
+
+    <span class="pull-right">
+        <a id="start-record" class="btn btn-success">
+            <i class="icon-plus-sign"></i> Start recording
+        </a>
+
+        <a id="stop-record" class="btn btn-danger">
+            <span class="icon-stop"></span> Stop recording
+        </a>
+
+        <a id="save-record" class="btn btn-primary">
+            <i class="icon-ok-circle"></i> Save recording
+        </a>
+    </span>
+
+        </h2>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-sm-12">
+
+
+        <div id="remoteVideo" style="z-index: 1;">
+        </div>
+
+        <video id="localVideo" style="width: 200px; height: 200px; position:absolute; z-index: 2; top:300px; left:453px; opacity: 1;"></video>
+
+
+
+    </div>
+
+</div>


### PR DESCRIPTION
Would like to deploy this so that I can test how it works when hosted elsewhere
and yet still using our stunserver.

---

This is the outline for a recording tool that would allow us to record
interviews with interesting redecentralisation people without the need
to use Google Hangouts. Currently uses a STUN server hosted at
redecentralise.net

Recording in WebRTC still seems a bit up in the air, and so we need to
wait until someone implements MediaStream recording (see the  spec
at http://www.w3.org/TR/mediastream-recording/) so that we can have
the server join as a participant (and then save to disk). Failing
that, or if impatience gets the better of us, we can check out
whether https://www.webrtc-experiment.com/RecordRTC/ will work if
the server is a (non-visible) participant to the conversation.

Will also need work to see if it is possible to switch between
video streams based on the when the host is not speaking. Without
that we'd just have to choose a single video-stream to record :(
