### PR TITLE
Perhaps one <h1> per page is enough.

### DIFF
--- a/radar/index.html
+++ b/radar/index.html
@@ -34,7 +34,7 @@ id: radar
 
   <div class="col-md-4">
 
-	<h1>Sign up</h1>
+	<h2>Sign up</h2>
 
 	<p class="lead">
 	   We'll email you when a new decentralized app gets good enough to try, use or share. 
@@ -58,7 +58,7 @@ id: radar
 	  <a target="_blank" href="/radar/feed.rss"><i class="icon-rss"></i> RSS feed</a>
 	</p>
 
-	<h1>What is "good enough"?</h1>
+	<h2>What is "good enough"?</h2>
 
 	<h2><span class="label label-primary">Try</span></h2>
 


### PR DESCRIPTION
... mostly because it wraps mid line which is awkward typographically...

Before:
![screen shot 2017-02-22 at 10 19 59](https://cloud.githubusercontent.com/assets/17229/23207295/b3556efa-f8e8-11e6-9dca-f0cde626919b.png)

After: 


![screen shot 2017-02-22 at 10 22 07](https://cloud.githubusercontent.com/assets/17229/23207318/cba95944-f8e8-11e6-8121-44b2c6da1f63.png)
