### PR TITLE
Put the labels before the names in the radar index

### DIFF
--- a/radar/index.html
+++ b/radar/index.html
@@ -12,7 +12,6 @@ id: radar
 		<div class="radar-listing">
 		  <img src="/assets/images/radar/{{ entry.icon }}">
 		  <h2>
-			<a href="{{ entry.url }}">{{ entry.title }}</a>
 			  {% if entry.status == "use" %} 
 				<span class="label label-info">Use</span>
 			  {% endif %}
@@ -25,6 +24,7 @@ id: radar
 			  {% if entry.status == "hold" %} 
 				<span class="label label-warning">Hold</span>
 			  {% endif %}
+			<a href="{{ entry.url }}">{{ entry.title }}</a>			  
 		  </h2>
 		  <p>{{ entry.intro }} 
 			<span class="listing-date">{{ entry.date | date: "%-d %b %Y"}}</span>


### PR DESCRIPTION
1) This makes it easier to scan for a label I'm interested in (I'm only interested in 'use')
2) This turns the label-title into an almost-sentence e.g. Use Firefox, Try Sandstorm