### PR TITLE
Add max-width:100% to blogpost images, so they fit

### DIFF
--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -268,3 +268,8 @@ body {
   margin-top: 32px;
   font-size: $font-size-large;
 }
+
+.blogpost img {
+  max-width: 100%;
+}
+


### PR DESCRIPTION
Just enough css to stop large images in blogposts from overflowing.